### PR TITLE
buildx를 이용하여 이미지 빌드 시 로컬 Docker 데몬에 저장하도록 빌드 명령어에 옵션 추가

### DIFF
--- a/.github/workflows/aws.yml
+++ b/.github/workflows/aws.yml
@@ -85,7 +85,7 @@ jobs:
         run: |
           IMAGE_ID=$ECR_REGISTRY/${{ env.ECR_REPOSITORY }}:$IMAGE_TAG
           LATEST_IMAGE_ID=$ECR_REGISTRY/${{ env.ECR_REPOSITORY }}:latest
-          docker buildx build --platform linux/amd64 -t $IMAGE_ID -f ${{ github.workspace }}/Dockerfile .
+          docker buildx build --load --platform linux/amd64 -t $IMAGE_ID -f ${{ github.workspace }}/Dockerfile .
           docker tag $IMAGE_ID $LATEST_IMAGE_ID
           docker push $IMAGE_ID
           docker push $LATEST_IMAGE_ID

--- a/.github/workflows/aws.yml
+++ b/.github/workflows/aws.yml
@@ -30,11 +30,6 @@ jobs:
           MYSQL_DATABASE: board_service
         ports:
           - 3306:3306
-        options: |
-          --health-cmd="mysqladmin ping"
-          --health-interval=10s
-          --health-timeout=5s
-          --health-retries=10
 
     steps:
       - name: Checkout


### PR DESCRIPTION
m1 맥북에서 프로젝트를 빌드하는 관계로 ECS 컨테이너 인스턴스의 환경과 다르게 빌드되는 문제로 인해 docker buildx 사용